### PR TITLE
script: repo.spring.io 권한, gradle 버전 변경에 의한 빌드 파일 수정

### DIFF
--- a/buildSrc/src/main/groovy/ComponentTestsPlugin.groovy
+++ b/buildSrc/src/main/groovy/ComponentTestsPlugin.groovy
@@ -28,7 +28,7 @@ class ComponentTestsPlugin implements Plugin<Project> {
 		project.eclipse.classpath.plusConfigurations << project.configurations.componentTestCompile
 
         project.task("componentTest", type: Test) {
-            testClassesDir = project.sourceSets.componentTest.output.classesDir
+            testClassesDirs = project.sourceSets.componentTest.output.classesDirs
             classpath = project.sourceSets.componentTest.runtimeClasspath
         }
 

--- a/buildSrc/src/main/groovy/IntegrationTestsPlugin.groovy
+++ b/buildSrc/src/main/groovy/IntegrationTestsPlugin.groovy
@@ -23,7 +23,7 @@ class IntegrationTestsPlugin implements Plugin<Project> {
         }
 
         project.task("integrationTest", type: Test) {
-            testClassesDir = project.sourceSets.integrationTest.output.classesDir
+            testClassesDirs = project.sourceSets.integrationTest.output.classesDirs
             classpath = project.sourceSets.integrationTest.runtimeClasspath
         }
 

--- a/ftgo-api-gateway/build.gradle
+++ b/ftgo-api-gateway/build.gradle
@@ -1,11 +1,9 @@
 buildscript {
     repositories {
-        maven {
-            url 'https://repo.spring.io/libs-milestone'
-        }
-        dependencies {
-            classpath "io.spring.gradle:dependency-management-plugin:$springDependencyManagementPluginVersion"
-        }
+        mavenCentral()
+    }
+    dependencies {
+        classpath "io.spring.gradle:dependency-management-plugin:$springDependencyManagementPluginVersion"
     }
 }
 

--- a/ftgo-order-service/build.gradle
+++ b/ftgo-order-service/build.gradle
@@ -3,9 +3,6 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
-        maven {
-            url 'https://repo.spring.io/libs-milestone'
-        }
     }
     dependencies {
         classpath "org.springframework.cloud:spring-cloud-contract-gradle-plugin:$springCloudContractDependenciesVersion"


### PR DESCRIPTION
**이슈 사항**
- gradle build failure
    - 익명 클라이언트 repo.spring.io 접근 불가 (권한)
    - `IntegrationTestsPlugin.groovy`,`ComponentsTestsPlugin.groovy` unknown property 문제
        - gradle JVM: Oracle OpenJDK version 11.0.11
        - property명 변경: `classDir` -> `classesDirs`


**Reference**
- https://stackoverflow.com/questions/54707148/gradle-could-not-get-unknown-property-classesdir-for-main-classes
- https://spring.io/blog/2022/12/14/notice-of-permissions-changes-to-repo-spring-io-january-2023